### PR TITLE
Fix reachy urdf 

### DIFF
--- a/reachy_description/urdf/reachy.urdf.xacro
+++ b/reachy_description/urdf/reachy.urdf.xacro
@@ -17,8 +17,8 @@
 
   <!-- config  -->
   <xacro:arg name="neck_config" default="$(find orbita3d_description)/config/fake.yaml" />
-  <xacro:arg name="right_arm_config" default="$(find arm_controller)/config/fake_arm.yaml" />
-  <xacro:arg name="left_arm_config" default="$(find arm_controller)/config/fake_arm.yaml" />
+  <xacro:arg name="right_arm_config" default="$(find arm_description)/config/fake_arm.yaml" />
+  <xacro:arg name="left_arm_config" default="$(find arm_description)/config/fake_arm.yaml" />
   <!-- config  -->
 
 


### PR DESCRIPTION
In the reachy urdf the fake arms are referenced to `arm_controller` node which does not exist any more. 
The new fake config files are in `arm_description` package. 