### PR TITLE
grace period before shutdown

### DIFF
--- a/reachy_bringup/launch/reachy.launch.py
+++ b/reachy_bringup/launch/reachy.launch.py
@@ -26,6 +26,7 @@ from launch_ros.actions import LifecycleNode, Node, SetUseSimTime
 from launch_ros.descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 from reachy2_sdk_api.reachy_pb2 import ReachyCoreMode
+
 from reachy_utils.config import (
     BETA,
     DVT,

--- a/reachy_utils/reachy_utils/launch.py
+++ b/reachy_utils/reachy_utils/launch.py
@@ -275,7 +275,6 @@ def clear_bags_and_logs(nb_runs_to_keep: int = 10):
     current_log_dir = get_current_run_log_dir()
     # Pre-filter, keeping only dir with non-empty rosbag
     for dir in dirs:
-
         # dont remove current log dir, ofc its quite empty
         if dir == current_log_dir:
             continue


### PR DESCRIPTION
Changed Rosbag behavior
From
* Keep the last five runs
* full run duration
* on disk
* very few topics

To
* keep no runs unless specifically asked to
* duration set to cache-size, so last n Mo
* RAM ring buffer
*  nearly all topics

Forced a list of saved topic, exhaustive one, a bit too much,
Some topics should be removed
