### PR TITLE
Add tripod to config

### DIFF
--- a/reachy_config/config/default/reachy.yaml
+++ b/reachy_config/config/default/reachy.yaml
@@ -57,6 +57,9 @@ mobile_base:
   version_hard: 1.2
   serial_number: MB-001
   version_soft: 1.1
+tripod:
+  enable: true
+  version_hard: 0.1
 
 reachy2_configuration:
   neck_config:

--- a/reachy_config/config/schema/reachy.yaml
+++ b/reachy_config/config/schema/reachy.yaml
@@ -199,6 +199,16 @@ mobile_base:
     version_soft:
       type: float
       required: true
+tripod:
+  type: dict
+  required: true
+  schema:
+    enable:
+      type: boolean
+      required: true
+    version_hard:
+      type: float
+      required: true
 
 reachy2_configuration:
   type: dict


### PR DESCRIPTION
We want to be able to access the tripod as a part from reachy2-sdk-server