### PR TITLE
Change tripod joint command for mujoco.

### DIFF
--- a/reachy_description/urdf/reachy.urdf.xacro
+++ b/reachy_description/urdf/reachy.urdf.xacro
@@ -458,18 +458,7 @@
       <state_interface name="effort">
         <param name="initial_value">0.0</param>
       </state_interface>
-
-
-      <xacro:unless value="$(arg use_mujoco)">
-        <command_interface name="position" />
-      </xacro:unless>
-      <xacro:if value="$(arg use_mujoco)">
-        <command_interface name="position_pid" />
-        <param name="position_kp">20</param>
-        <param name="position_ki">10</param>
-        <param name="position_kd">1</param>
-        <param name="position_i_max">10000</param>
-      </xacro:if>
+      <command_interface name="position" />
 
 
     </joint>


### PR DESCRIPTION
Could not change the height of the tripod in mujoco mode with the SDK client (`reachy.tripod.set_height(1.2)`)  : switch the joint command interface from "position pid" to "position" in mujoco mode, such as the other modes. 