### PR TITLE
Fix shoulder roll limits.

### DIFF
--- a/reachy_description/urdf/arm.urdf.xacro
+++ b/reachy_description/urdf/arm.urdf.xacro
@@ -82,7 +82,7 @@
 
     <xacro:if value="${side == 'left'}">
       <xacro:property name="reflect" value="-1" />
-      <xacro:property name="min_shoulder_roll" value="-0.0" />
+      <xacro:property name="min_shoulder_roll" value="-0.51" />
       <xacro:property name="max_shoulder_roll" value="${pi}" />
       <xacro:property name="shoulder_axis1_inverted" value="0" />
       <xacro:property name="shoulder_axis2_inverted" value="0" />
@@ -93,7 +93,7 @@
     <xacro:if value="${side == 'right'}">
       <xacro:property name="reflect" value="1" />
       <xacro:property name="min_shoulder_roll" value="-${pi}" />
-      <xacro:property name="max_shoulder_roll" value="0.0" />
+      <xacro:property name="max_shoulder_roll" value="0.51" />
       <xacro:property name="shoulder_axis1_inverted" value="1" />
       <xacro:property name="shoulder_axis2_inverted" value="0" />
       <xacro:property name="elbow_axis1_inverted" value="1" />


### PR DESCRIPTION
The shoulder roll was limited between -3.14 and 0 for the right arm, and 0 and 3.14 for the left arm, because of the urdf generated by the launch. 

You can try without and with the modification, by doing : 
```python3
from reachy2_sdk import ReachySDK
reachy = ReachySDK('localhost')
reachy.l_arm.shoulder.roll.goto(-20)
print(reachy.l_arm.get_current_positions()[1])
reachy.r_arm.shoulder.roll.goto(20)
print(reachy.r_arm.get_current_positions()[1])
```

